### PR TITLE
iowin32.c only for win

### DIFF
--- a/hbxlsxwriter.hbc
+++ b/hbxlsxwriter.hbc
@@ -3,7 +3,7 @@ description=LibXlsxWriter wrapper (XLSX)
 incpaths=.
 
 #headers=${hb_name}.ch
-libpaths=lib/${hb_plat}/${hb_comp}/${hb_cpu}
+libpaths=lib/${hb_plat}/${hb_comp}
 
 libs=${hb_name}
 

--- a/hbxlsxwriter.hbp
+++ b/hbxlsxwriter.hbp
@@ -50,7 +50,7 @@ src/hb_others.prg
 libxlsxwriter\third_party\minizip\ioapi.c
 libxlsxwriter\third_party\minizip\zip.c
 libxlsxwriter\third_party\minizip\unzip.c
-libxlsxwriter\third_party\minizip\iowin32.c
+{win}libxlsxwriter\third_party\minizip\iowin32.c
 
 libxlsxwriter\third_party\tmpfileplus\tmpfileplus.c
 

--- a/hbxlsxwriter.hbp
+++ b/hbxlsxwriter.hbp
@@ -85,3 +85,5 @@ libxlsxwriter/src/xmlwriter.c
 -cflag=-DUSE_NO_MD5
 # -cflag=-DUSE_STANDARD_TMPFILE
 {allbcc}-cflag=-DUSE_FILE32API
+
+$hb_pkg_install.hbm


### PR DESCRIPTION
On linux Tumbleweed compilation (gcc) terminated due to missing windows.h:

jan@localhost:~/fphbxlsxwriter> hbmk2 hbxlsxwriter.hbp
hbmk2: Dependency 'xlsxwriter' found: libxlsxwriter/include
hbmk2: Dependency 'zlib' found: /usr/include
Harbour 3.2.0dev (r2511171214)
Copyright (c) 1999-2025, https://harbour.github.io/
Compiling 'hbxlsxwriter.hbx'...
Lines 340, Functions/Procedures 1
Generating C source output to '/tmp/hbmk_foktzx.dir/hbxlsxwriter.c'... Done.
Compiling 'src/hb_others.prg'...
Lines 35, Functions/Procedures 1
Generating C source output to '/tmp/hbmk_foktzx.dir/hb_others.c'... Done.
../../home/jan/fphbxlsxwriter/src/hb_worksheet.c: In function ‘HB_FUN_WORKSHEET_DATA_VALIDATION_CELL’:
../../home/jan/fphbxlsxwriter/src/hb_worksheet.c:2414:42: warning: assignment to ‘const char **’ from incompatible pointer type ‘char **’ [-Wincompatible-pointer-types]
 2414 |                   validation->value_list = (char **) hb_xalloc( sizeof( char* ) * (nLen+1) );
      |                                          ^
../../home/jan/fphbxlsxwriter/src/hb_worksheet.c:2440:48: warning: passing argument 1 of ‘hb_xfree’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
 2440 |                hb_xfree( validation->value_list[nIndex] );
      |                          ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
In file included from ../../home/jan/fphbxlsxwriter/src/hb_worksheet.c:24:
/home/jan/hb32/include/hbapi.h:492:44: note: expected ‘void *’ but argument is of type ‘const char *’
  492 | extern HB_EXPORT void     hb_xfree( void * pMem );                    /* frees memory */
      |                                     ~~~~~~~^~~~
In file included from ../../home/jan/fphbxlsxwriter/libxlsxwriter/third_party/minizip/iowin32.c:18:
../../home/jan/fphbxlsxwriter/libxlsxwriter/third_party/minizip/iowin32.h:14:10: fatal error: windows.h: No such file or directory
   14 | #include <windows.h>
      |          ^~~~~~~~~~~
compilation terminated.
